### PR TITLE
Configure heartbeat mode for avoiding premature killing

### DIFF
--- a/recipe/pipeline.py
+++ b/recipe/pipeline.py
@@ -100,6 +100,7 @@ def main(test_run, refresh, data_bucket, project_name, run_flow):
             'AWS_SECRET': os.environ.get('AWS_SECRET', None),
             'OOI_USERNAME': os.environ.get('OOI_USERNAME', None),
             'OOI_TOKEN': os.environ.get('OOI_TOKEN', None),
+            'PREFECT__CLOUD__HEARTBEAT_MODE': 'thread',
         },
         'cpu': '2 vcpu',
         'memory': '16 GB',


### PR DESCRIPTION
This PR sets the prefect cloud heartbeat mode to `thread` to avoid system kernel terminating heartbeat process prematurely. See https://docs.prefect.io/orchestration/concepts/services.html#heartbeat-configuration